### PR TITLE
Add tabindex -1 to the inc / dec elements

### DIFF
--- a/source/javascripts/jquery.super_number.js
+++ b/source/javascripts/jquery.super_number.js
@@ -25,7 +25,7 @@
       $.each(["in", "de"], function(i, v) {
         var c = v + "crement",
             $e = s.controls.$el.clone().text(s.controls[c]).data(super_number.name, s)
-                  .addClass(c);
+                  .addClass(c).attr('tabindex', -1);
         s.hide_on_blur && $e.hide();
         s.controls["$" + c] = $e.appendTo($c);
       });


### PR DESCRIPTION
Weird things happen when tabbing between elements because of the way the increment / decrement elements are hidden from the page.  This ensures that you don't tab to an element right before it's hidden from the DOM.
